### PR TITLE
Update autologin after activation

### DIFF
--- a/logview/backend/passport/localStrategy.js
+++ b/logview/backend/passport/localStrategy.js
@@ -50,3 +50,28 @@ passport.use(
 		}
 	)
 );
+
+passport.use(
+	'local.activationSignin',
+	new LocalStrategy(
+		{
+			usernameField: 'activationToken',
+			passwordField: 'activationToken'
+		},
+		(username, password, done) => {
+			userService
+				.findByUserActivationToken(username)
+				.then(user => {
+					if (!user)
+						return done(null, false, {
+							message:
+								'No account with that activation token exists'
+						});
+					return done(null, user);
+				})
+				.catch(err => {
+					return done(err);
+				});
+		}
+	)
+);

--- a/logview/backend/routes/api/signinRoutes.js
+++ b/logview/backend/routes/api/signinRoutes.js
@@ -37,6 +37,7 @@ router.get(`/logout`, isLoggedInMiddlewre, (req, res, next) => {
 
 router.post(
 	'/user/activate/:activationToken',
+	passport.authenticate('local.activationSignin'),
 	async (req, res, next) => {
 		try {
 			const user = await userService.findByUserActivationToken(

--- a/logview/frontend/src/containers/EmailConfirm/EmailTokenConfirm.tsx
+++ b/logview/frontend/src/containers/EmailConfirm/EmailTokenConfirm.tsx
@@ -15,11 +15,11 @@ import { History } from 'history';
 interface EmailTokenProps {
 	history: History;
 	actions: { userEmailActivation: Function };
+	isLoggedIn: boolean;
+	fetchingUserStatus: string;
 }
 
-interface EmailTokenState {
-	confirmed: boolean;
-}
+interface EmailTokenState {}
 
 class EmailTokenConfirm extends React.Component<
 	EmailTokenProps,
@@ -27,52 +27,55 @@ class EmailTokenConfirm extends React.Component<
 > {
 	constructor(props: any) {
 		super(props);
-
-		this.state = {
-			confirmed: false
-		};
+		this.state = {};
 	}
 
 	componentDidMount() {
 		this.props.actions.userEmailActivation(
 			this.props.history.location.search.split('=')[1]
 		);
-		this.setState({ confirmed: true });
 	}
 
 	render() {
+		const { isLoggedIn, fetchingUserStatus } = this.props;
 		return (
-			<PasswordResetContainer>
-				<PasswordWrapper>
-					{this.state.confirmed ? (
-						<React.Fragment>
-							<Title>Email Successfully Confirmed!</Title>
-							<p>Some sort of image will be here</p>
-							<Submit>
-								<Link to="/login">Proceed to Login</Link>
-							</Submit>
-						</React.Fragment>
-					) : (
-						<React.Fragment>
-							<div>
-								<Title>
-									Sorry, your email couldn't be confirmed!
-								</Title>
-								<CenteredText>
-									Try following the link again, please!
-								</CenteredText>
-							</div>
-							<p>Some sort of image will be here</p>
-						</React.Fragment>
-					)}
-				</PasswordWrapper>
-			</PasswordResetContainer>
+			(fetchingUserStatus === 'success' ||
+				fetchingUserStatus === 'failed') && (
+				<PasswordResetContainer>
+					<PasswordWrapper>
+						{isLoggedIn ? (
+							<React.Fragment>
+								<Title>Email Successfully Confirmed!</Title>
+								<p>Some sort of image will be here</p>
+								{/* <Submit> */}
+								<Link to="/dashboard/quickstart">
+									Proceed to Quickstart
+								</Link>
+								{/* </Submit> */}
+							</React.Fragment>
+						) : (
+							<React.Fragment>
+								<div>
+									<Title>
+										Sorry, your email couldn't be confirmed!
+									</Title>
+									<CenteredText>
+										Try following the link again, please!
+									</CenteredText>
+								</div>
+								<p>Some sort of image will be here</p>
+							</React.Fragment>
+						)}
+					</PasswordWrapper>
+				</PasswordResetContainer>
+			)
 		);
 	}
 }
 
-const mapStateToProps = ({ fetchingUserStatus }) => ({
-	fetchingUserStatus
+const mapStateToProps = ({ fetchingUserStatus, isLoggedIn }) => ({
+	fetchingUserStatus,
+	isLoggedIn
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/logview/frontend/src/redux/user/actions.tsx
+++ b/logview/frontend/src/redux/user/actions.tsx
@@ -89,7 +89,7 @@ export interface UserChangePasswordSuccess {
 /* email activation */
 export interface UserEmailActivation {
 	type: constants.USER_EMAIL_ACTIVATION;
-	token: string;
+	activationToken: string;
 }
 
 export interface UserEmailActivationFail {
@@ -300,10 +300,12 @@ export function fetchUser(): FetchUser {
 	};
 }
 
-export function userEmailActivation(token: string = ''): UserEmailActivation {
+export function userEmailActivation(
+	activationToken: string = ''
+): UserEmailActivation {
 	return {
 		type: constants.USER_EMAIL_ACTIVATION,
-		token
+		activationToken
 	};
 }
 

--- a/logview/frontend/src/redux/user/reducer.tsx
+++ b/logview/frontend/src/redux/user/reducer.tsx
@@ -60,11 +60,10 @@ export function fetchingState(state = 'unstarted', action: UserAction) {
 
 export function isLoggedInState(state = false, action: UserAction) {
 	switch (action.type) {
-		case constants.USER_IS_LOGGED_SUCCESS:
-			return action.payload;
 		case constants.USER_LOGIN_SUCCESS:
+		case constants.USER_EMAIL_ACTIVATION_SUCCESS:
 			return true;
-		case constants.USER_IS_LOGGED_FAILED:
+		case constants.USER_LOGOUT_SUCCESS:
 			return false;
 		default:
 			return state;

--- a/logview/frontend/src/redux/user/sagas.tsx
+++ b/logview/frontend/src/redux/user/sagas.tsx
@@ -54,7 +54,7 @@ function* userLogin(action: UserLogin) {
 			}
 		});
 
-		sessionStorage.setItem('user', action.email);
+		sessionStorage.setItem('observerUser', action.email);
 		window.location.href = window.location.href;
 		// yield put(push('/dashboard/quickstart'));
 	} catch (error) {
@@ -66,7 +66,7 @@ function* userLogin(action: UserLogin) {
 
 function* userLogout(action: UserLogout) {
 	try {
-		sessionStorage.setItem('user', '');
+		sessionStorage.setItem('observerUser', '');
 
 		yield call(userAPI.logoutUser);
 
@@ -81,21 +81,6 @@ function* userLogout(action: UserLogout) {
 	} catch (error) {
 		yield put({
 			type: constants.USER_LOGOUT_FAILED
-		});
-	}
-}
-
-function* userIsLogged(action: UserIsLogged) {
-	try {
-		const isLogged = yield call(isLoggedIn);
-
-		yield put({
-			type: constants.USER_IS_LOGGED_SUCCESS,
-			payload: isLogged
-		});
-	} catch (error) {
-		yield put({
-			type: constants.USER_IS_LOGGED_FAILED
 		});
 	}
 }
@@ -143,7 +128,11 @@ function* userChangePassword(action: UserChangePassword) {
 
 function* userEmailActivation(action: UserEmailActivation) {
 	try {
-		yield call(userAPI.activateUser, action.token);
+		const currentUser = yield call(userAPI.activateUser, {
+			activationToken: action.activationToken
+		});
+
+		sessionStorage.setItem('observerUser', currentUser.data.email);
 
 		yield put({
 			type: constants.USER_EMAIL_ACTIVATION_SUCCESS
@@ -152,8 +141,6 @@ function* userEmailActivation(action: UserEmailActivation) {
 		yield put({
 			type: constants.USER_EMAIL_ACTIVATION_FAILED
 		});
-	} finally {
-		yield put(push('/login'));
 	}
 }
 
@@ -197,7 +184,6 @@ export default function* userSaga() {
 		takeLatest(constants.USER_REGISTER, userRegister),
 		takeLatest(constants.USER_LOGIN, userLogin),
 		takeLatest(constants.USER_LOGOUT, userLogout),
-		takeLatest(constants.USER_IS_LOGGED, userIsLogged),
 		takeLatest(constants.USER_CHANGE_PASSWORD, userChangePassword),
 		takeLatest(constants.USER_RESET_PASSWORD, userResetPassword),
 		takeLatest(constants.USER_EMAIL_ACTIVATION, userEmailActivation),

--- a/logview/frontend/src/router/routes.tsx
+++ b/logview/frontend/src/router/routes.tsx
@@ -38,11 +38,9 @@ interface RouterState {
 class Router extends React.Component<RouterProps, RouterState> {
 	constructor(props: any) {
 		super(props);
-		this.state = { loggedUser: sessionStorage.getItem('user') };
+		this.state = { loggedUser: sessionStorage.getItem('observerUser') };
 	}
-	componentDidMount() {
-		this.props.actions.userIsLogged();
-	}
+	componentDidMount() {}
 
 	render() {
 		const { isLoggedIn, fetchingUserStatus } = this.props;

--- a/logview/frontend/src/services/domains/user.ts
+++ b/logview/frontend/src/services/domains/user.ts
@@ -2,6 +2,7 @@ import api from 'src/services/adapter';
 import {
 	UserState,
 	UserLoginState,
+	UserActivationState,
 	UserResetPasswordState,
 	UserChangePasswordState,
 	InviteUserState
@@ -44,10 +45,11 @@ export default {
 			newPassword
 		);
 	},
-	activateUser: (activationToken: string) => {
+	activateUser: (UserActivationState: UserActivationState) => {
 		return api.makeRequest(
-			`/api/user/activate/${activationToken}`,
-			api.requestType.POST
+			`/api/user/activate/${UserActivationState.activationToken}`,
+			api.requestType.POST,
+			UserActivationState
 		);
 	},
 	inviteUser: (invite: InviteUserState) => {


### PR DESCRIPTION
- Додав паспорт для автентифікації (в нас немає доступного не-хешованого паролю, тому автентифікацію робимо по активаційному токену як ім'я та пароль)
- після цього дані про автентифікацію вношу і в сесію, і в стейт, але беру зі стейту (бо без перезавантаження дані з асинхронної саги недоступні для компонента, а зі стейтом апдейт відбувається автоматично)
є ідея спробувати так і з Роутер-компонентом
- виправив неузгодженості всюди в екшенах, редюсері, адаптері (token і activationToken, activationToken був як object і як string, додав відсутній payload для POST-запиту)
- змінив у компоненті button на Link, бо не працювало посилання