### PR TITLE
Vv 78 Add email in EmailConfirm; Move Proceed to Quickstart button to the center of the page

### DIFF
--- a/logview/frontend/src/containers/EmailConfirm/EmailConfirm.tsx
+++ b/logview/frontend/src/containers/EmailConfirm/EmailConfirm.tsx
@@ -1,4 +1,8 @@
 import * as React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import { UserState } from 'src/types/UserState';
 import {
 	Background,
 	PasswordResetContainer,
@@ -7,7 +11,16 @@ import {
 	EmailContainer
 } from '../../styles/Styles';
 
-class EmailConfirm extends React.Component {
+interface EmailConfirmState {}
+
+interface EmailConfirmProps {
+	user: UserState;
+}
+
+class EmailConfirm extends React.Component<
+	EmailConfirmProps,
+	EmailConfirmState
+> {
 	constructor(props: any) {
 		super(props);
 	}
@@ -15,7 +28,7 @@ class EmailConfirm extends React.Component {
 	componentDidMount() {}
 
 	render() {
-		let user = sessionStorage.getItem('observerUser');
+		let user = this.props.user;
 
 		return (
 			<Background>
@@ -23,10 +36,10 @@ class EmailConfirm extends React.Component {
 					<EmailContainer>
 						<Title>Email sent!</Title>
 						<CenteredText>
-							We've sent an email to <b>{user}</b> to confirm
-							validity of your email address. After receiving the
-							email, follow the link provided to complete the
-							registration
+							We've sent an email to <b>{user.email}</b> to
+							confirm validity of your email address. After
+							receiving the email, follow the link provided to
+							complete the registration
 						</CenteredText>
 					</EmailContainer>
 				</PasswordResetContainer>
@@ -35,4 +48,18 @@ class EmailConfirm extends React.Component {
 	}
 }
 
-export default EmailConfirm;
+const mapStateToProps = ({ fetchingUserStatus, user }) => ({
+	fetchingUserStatus,
+	user
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+	actions: bindActionCreators({}, dispatch)
+});
+
+const EmailConfirmConnected = connect(
+	mapStateToProps,
+	mapDispatchToProps
+)(EmailConfirm);
+
+export default EmailConfirmConnected;

--- a/logview/frontend/src/containers/EmailConfirm/EmailTokenConfirm.tsx
+++ b/logview/frontend/src/containers/EmailConfirm/EmailTokenConfirm.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Title, Submit, PasswordWrapper } from '../../styles/Styles';
+import {
+	Title,
+	Submit,
+	PasswordWrapper,
+	PasswordResetContainer,
+	CenteredText
+} from '../../styles/Styles';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { userEmailActivation } from 'src/redux/user/actions';
@@ -32,18 +38,35 @@ class EmailTokenConfirm extends React.Component<
 	}
 
 	render() {
-		const { fetchingUserStatus } = this.props;
+		const { isLoggedIn, fetchingUserStatus } = this.props;
 		return (
 			(fetchingUserStatus === 'success' ||
 				fetchingUserStatus === 'failed') && (
-				<PasswordWrapper>
-					<Title>Email Successfully Confirmed!</Title>
-					<Submit>
-						<Link to="/dashboard/quickstart">
-							Proceed to Quickstart
-						</Link>
-					</Submit>
-				</PasswordWrapper>
+				<PasswordResetContainer>
+					<PasswordWrapper>
+						{isLoggedIn ? (
+							<React.Fragment>
+								<Title>Email Successfully Confirmed!</Title>
+								// seems link within button doesn't work with
+								Firefox
+								<Submit>
+									<Link to="/dashboard/quickstart">
+										Proceed to Quickstart
+									</Link>
+								</Submit>
+							</React.Fragment>
+						) : (
+							<React.Fragment>
+								<Title>
+									Sorry, your email couldn't be confirmed!
+								</Title>
+								<CenteredText>
+									Try following the link again, please!
+								</CenteredText>
+							</React.Fragment>
+						)}
+					</PasswordWrapper>
+				</PasswordResetContainer>
 			)
 		);
 	}


### PR DESCRIPTION
Fixed email rendering in EmailConfirm
Move Proceed to Quickstart button to the center of the page

(Proceed to Quickstart button seems not to work with Firefox)